### PR TITLE
ci: bump version in main Lit docs

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -54,6 +54,27 @@ jobs:
         with:
           repository: Lightning-AI/lightning
           token: ${{ secrets.PAT_GHOST }}
+      - name: Bump the version in docs
+        run: |
+          import os, re
+
+          tag = os.environ.get("TAG", "???")
+          fpath = "docs/source-pytorch/conf.py"
+          with open(fpath, "r") as fp:
+              conf = fp.readlines()
+          found = False
+          for i, ln in enumerate(conf):
+              if "lightning-Habana" in ln:
+                  found = True
+              if found and "checkout=" in ln:
+                  ln = re.sub(r'checkout=".+"', f'checkout="{tag}"', ln)
+                  conf[i] = ln
+                  break
+          else:
+              raise RuntimeError(f"Failed to find checkout= for `lightning-Habana` in {fpath}")
+          with open(fpath, "w") as fp:
+              fp.writelines(conf)
+        shell: python
 
       - name: Create Pull Request
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Turned out several releases were not updated as PR is not created with empty diff
the bump to last 1.3 is injected to https://github.com/Lightning-AI/pytorch-lightning/pull/19248

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
