### PR TITLE
`aot_hpu_training_backend` to be deprecated

### DIFF
--- a/.azure/hpu-tests.yml
+++ b/.azure/hpu-tests.yml
@@ -114,9 +114,15 @@ jobs:
           tests/test_pytorch/test_dynamic_shapes.py \
           tests/test_pytorch/test_datamodule.py \
           tests/test_pytorch/test_profiler.py \
-          tests/test_pytorch/test_compile.py \
           --hpus 1 --junitxml=hpu_test-torch-results.xml
       displayName: 'HPU General tests'
+
+    - bash: |
+        python -m pytest -sv tests/test_pytorch/test_compile.py \
+        --hpus 1 --junitxml=hpu_compile_test-results.xml
+      env:
+        PT_HPU_LAZY_MODE: 0
+      displayName: 'HPU torch compile tests'
 
     - bash: |
         python -m pytest -sv tests/test_pytorch/test_deepspeed.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
--
+- `aot_hpu_training_backend` will be deprecated. Use `hpu_backend` instead for torch compile with hpu ([#148](https://github.com/Lightning-AI/lightning-Habana/pull/148))
 
 
 ## [1.3.0] - 2023-12-06

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -704,14 +704,19 @@ Using ``torch.compile``
 ------------------------
 
 PyTorch Eager mode and Eager mode with `torch.compile` are available for early preview.
-The following compile backends are now available to support HPU: `aot_hpu_training_backend` for training and `aot_hpu_inference_backend` for inference.
+The following compile backends are now available to support HPU: `hpu_backend` for training and `aot_hpu_training_backend` for inference.
 
 .. code-block:: python
 
-    compiled_train_model = torch.compile(model_to_train, backend="aot_hpu_training_backend")
+    compiled_train_model = torch.compile(model_to_train, backend="hpu_backend")
     compiled_eval_model = torch.compile(model_to_eval, backend="aot_hpu_inference_backend")
 
 Please refer to `GAUDI Release Notes <https://docs.habana.ai/en/latest/Release_Notes/GAUDI_Release_Notes.html>`_
+
+.. note::
+
+    For models using torch.compile, `aot_hpu_training_backend` is now deprecated and will be removed in a future release.
+    Replace `aot_hpu_training_backend` with `hpu_backend`.
 
 
 ----

--- a/tests/test_pytorch/test_compile.py
+++ b/tests/test_pytorch/test_compile.py
@@ -43,7 +43,7 @@ def _is_compile_allowed():
 @pytest.mark.usefixtures("_is_compile_allowed")
 def test_compiler_context(tmp_path):
     model = BoringModel()
-    compiled_model = torch.compile(model, backend="aot_hpu_training_backend")
+    compiled_model = torch.compile(model, backend="hpu_backend")
     assert model._compiler_ctx is compiled_model._compiler_ctx  # shared reference
 
 
@@ -51,7 +51,7 @@ def test_compiler_context(tmp_path):
 @pytest.mark.usefixtures("_is_compile_allowed")
 def test_lightning_compile_uncompile():
     model = BoringModel()
-    compiled_model = torch.compile(model, backend="aot_hpu_training_backend")
+    compiled_model = torch.compile(model, backend="hpu_backend")
 
     def has_dynamo(fn):
         return any(el for el in dir(fn) if el.startswith("_torchdynamo"))
@@ -88,7 +88,7 @@ def test_compiled_model_to_log_metric(tmp_path):
             return loss
 
     model = MyModel()
-    compiled_model = torch.compile(model, backend="aot_hpu_training_backend")
+    compiled_model = torch.compile(model, backend="hpu_backend")
 
     _strategy = SingleHPUStrategy()
 
@@ -129,7 +129,7 @@ class LitClassifier(LightningModule):
 def test_compiled_model_with_datamodule_and_log_metric(tmp_path):
     dm = MNISTDataModule(batch_size=32)
     model = LitClassifier()
-    compiled_model = torch.compile(model, backend="aot_hpu_training_backend")
+    compiled_model = torch.compile(model, backend="hpu_backend")
     _strategy = SingleHPUStrategy()
 
     trainer = Trainer(
@@ -149,7 +149,7 @@ def test_compiled_model_with_datamodule_and_log_metric(tmp_path):
 def test_trainer_fit_with_compiled_model(tmp_path):
     """Tests compiled BoringModel on HPU."""
     model = BoringModel()
-    compiled_model = torch.compile(model, backend="aot_hpu_training_backend")
+    compiled_model = torch.compile(model, backend="hpu_backend")
 
     _strategy = SingleHPUStrategy()
     _plugins = [HPUPrecisionPlugin(precision="bf16-mixed")]
@@ -180,7 +180,7 @@ class Net(nn.Module):
 def test_trainer_with_nn_module(tmp_path):
     device = torch.device("hpu")
     model = Net().to(device)
-    torch.compile(model, backend="aot_hpu_training_backend")
+    torch.compile(model, backend="hpu_backend")
 
 
 @pytest.mark.parametrize("hpus", [1])
@@ -189,7 +189,7 @@ def test_all_stages_with_compile(tmpdir, hpus):
     """Tests all the model stages using BoringModel on HPU."""
     model_to_train = BoringModel()
     model_to_eval = BoringModel()
-    compiled_train_model = torch.compile(model_to_train, backend="aot_hpu_training_backend")
+    compiled_train_model = torch.compile(model_to_train, backend="hpu_backend")
     compiled_eval_model = torch.compile(model_to_eval, backend="aot_hpu_inference_backend")
 
     _strategy = SingleHPUStrategy()
@@ -215,7 +215,7 @@ def test_all_stages_with_compile(tmpdir, hpus):
 def test_parallel_strategy_with_compile(tmp_path, hpus):
     """Tests compiled BoringModel on HPU."""
     model = BoringModel()
-    compiled_model = torch.compile(model, backend="aot_hpu_training_backend")
+    compiled_model = torch.compile(model, backend="hpu_backend")
 
     _plugins = [HPUPrecisionPlugin(precision="bf16-mixed")]
     parallel_hpus = [torch.device("hpu")] * hpus


### PR DESCRIPTION
Use `hpu_backend` for training with torch compile on hpu

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
