### PR TITLE
Update contextmanager to be compatible with Python 3.8

### DIFF
--- a/src/lightning_habana/pytorch/plugins/precision.py
+++ b/src/lightning_habana/pytorch/plugins/precision.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager
-from typing import Any, Generator, Literal, Mapping, Optional, Union
+from typing import Any, ContextManager, Generator, Literal, Mapping, Optional, Union
 
 import torch
 from lightning_utilities import module_available
@@ -97,7 +97,7 @@ class HPUPrecisionPlugin(Precision):
                 _replace_layers(module)
         return module
 
-    def autocast_context_manager(self) -> Union[Generator[Any, Any, Any], torch.autocast]:
+    def autocast_context_manager(self) -> Union[ContextManager[Any], torch.autocast]:
         """Return Autocast context manager."""
         if self.fp8_train_available:
             return _nested_precision_cm(fp8_enabled=(self.precision == "fp8"), recipe=self.recipe)

--- a/src/lightning_habana/pytorch/plugins/precision.py
+++ b/src/lightning_habana/pytorch/plugins/precision.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import _GeneratorContextManager, contextmanager
+from contextlib import contextmanager
 from typing import Any, Generator, Literal, Mapping, Optional, Union
 
 import torch
@@ -97,7 +97,7 @@ class HPUPrecisionPlugin(Precision):
                 _replace_layers(module)
         return module
 
-    def autocast_context_manager(self) -> Union[_GeneratorContextManager[Any], torch.autocast]:
+    def autocast_context_manager(self) -> Union[Generator[Any, Any, Any], torch.autocast]:
         """Return Autocast context manager."""
         if self.fp8_train_available:
             return _nested_precision_cm(fp8_enabled=(self.precision == "fp8"), recipe=self.recipe)


### PR DESCRIPTION
<details>
  <summary><b>Modify typing to support python 3.8</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?
Fix support for python 3.8.

Fixes # (issue).
in python 3.8: 
using "_GeneratorContextManager[Any]" as typing gives
TypeError: 'ABCMeta' object is not subscriptable

typing in python 3.8 does not recognize _GeneratorContextManager as a type, due to which it gets treated as an iterable, leading to this error.
This was changed in Python 3.9 with type aliases. Original code works for Python >= 3.9.

Changed typing to use ContextManager from typing and extend support for python 3.8.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
