### PR TITLE
Added check for patching of ProfilerActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix for "No profiler activity found" when using HPUProfiler. Added check for patching of ProfilerActivity. ([#172](https://github.com/Lightning-AI/lightning-Habana/pull/172))
+- Fixed "No profiler activity found" error with HPUProfiler. ([#172](https://github.com/Lightning-AI/lightning-Habana/pull/172))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix for "No profiler activity found" when using HPUProfiler. Added check for patching of ProfilerActivity. ([#172](https://github.com/Lightning-AI/lightning-Habana/pull/172))
 
 ### Removed
 

--- a/src/lightning_habana/pytorch/profiler/profiler.py
+++ b/src/lightning_habana/pytorch/profiler/profiler.py
@@ -103,9 +103,15 @@ class HPUProfiler(PyTorchProfiler):
             record_module_names=record_module_names,
             **profiler_kwargs,
         )
-
         self.profiler: Optional[_PROFILER] = None
         self._profiler_kwargs["activities"] = self.profile_hpu_activities(self._profiler_kwargs.get("activities", None))
+        assert self._activities_patched(
+            self._profiler_kwargs["activities"]
+        ), "lightning_habana should be imported before lightning to use HPUProfiler."
+
+    def _activities_patched(self, activities: List["ProfilerActivity"]) -> bool:
+        """Checks ProfilerActivity is patched by habana_frameworks."""
+        return all(not isinstance(activity, torch._C._profiler.ProfilerActivity) for activity in activities)
 
     def profile_hpu_activities(self, activities) -> List["ProfilerActivity"]:  # type: ignore
         if not _KINETO_AVAILABLE:

--- a/tests/test_pytorch/test_profiler.py
+++ b/tests/test_pytorch/test_profiler.py
@@ -347,7 +347,12 @@ def test_hpu_profiler_lightning_habana_incorrect_import_order(tmpdir):
     # Code with incorrect import order (lightning before lightning_habana)
     code = """
 def _incorrect_imports():
-    import lightning
+    from lightning_utilities import module_available
+
+    if module_available("lightning"):
+        import lightning
+    elif module_available("pytorch_lightning"):
+        import pytorch_lightning
     from lightning_habana import HPUProfiler
 
     HPUProfiler()

--- a/tests/test_pytorch/test_profiler.py
+++ b/tests/test_pytorch/test_profiler.py
@@ -17,6 +17,7 @@ import json
 import os
 import platform
 from contextlib import nullcontext
+from subprocess import run
 
 import pytest
 import torch
@@ -335,3 +336,35 @@ def test_hpu_profiler_env(monkeypatch):
     monkeypatch.setenv("HABANA_PROFILE", "1")
     with pytest.raises(AssertionError, match="`HABANA_PROFILE` should not be set when using `HPUProfiler`"):
         HPUProfiler()
+
+
+def test_hpu_profiler_lightning_habana_incorrect_import_order(tmpdir):
+    """Tests import order of lightning_hanbana wrt lightning.
+
+    Required for correctly patching PyTorchProfiler with HPU activities.
+
+    """
+    # Code with incorrect import order (lightning before lightning_habana)
+    code = """
+def _incorrect_imports():
+    import lightning
+    from lightning_habana import HPUProfiler
+
+    HPUProfiler()
+
+_incorrect_imports()
+"""
+
+    # Write incorrect code to a file and run code in a new interpreter, Avoids use of modules from parent.
+    file_name = os.path.join(tmpdir, "script.py")
+
+    with open(file_name, "w", encoding="utf-8") as file:
+        file.write(code)
+
+    # Execute
+    p = run(["python", file_name], capture_output=True, check=False)
+
+    assert p.returncode != 0
+    assert (
+        "AssertionError: lightning_habana should be imported before lightning to use HPUProfiler" in p.stderr.decode()
+    )


### PR DESCRIPTION
<details>
  <summary><b>Added check for patching of ProfilerActivity</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Added check for patching of ProfilerActivity. Required for using HPUProfiler.
For patching activities correctly, it is required to import lightning_habana prior to import for lightning.

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
