### PR TITLE
Add fp8 training and inference support to deepspeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Intel Gaudi Profiler. Deprecate `HABANA_PROFILE` environment variable from HPUProfiler. ([#158](https://github.com/Lightning-AI/lightning-Habana/pull/158))
 - Added support for FP8 inference. ([#162](https://github.com/Lightning-AI/lightning-Habana/pull/162))
 - Added support for LightningCLI. ([#173](https://github.com/Lightning-AI/lightning-Habana/pull/173))
-- Added support for FP8 inference with DeepSpeed([#176](https://github.com/Lightning-AI/lightning-Habana/pull/173))
+- Added support for FP8 inference with DeepSpeed. ([#176](https://github.com/Lightning-AI/lightning-Habana/pull/173))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Intel Gaudi Profiler. Deprecate `HABANA_PROFILE` environment variable from HPUProfiler. ([#158](https://github.com/Lightning-AI/lightning-Habana/pull/158))
 - Added support for FP8 inference. ([#162](https://github.com/Lightning-AI/lightning-Habana/pull/162))
 - Added support for LightningCLI. ([#173](https://github.com/Lightning-AI/lightning-Habana/pull/173))
-- Added support for FP8 inference with DeepSpeed([#176](https://github.com/Lightning-AI/lightning-Habana/pull/176))
+- Added support for FP8 inference with DeepSpeed. ([#176](https://github.com/Lightning-AI/lightning-Habana/pull/176))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Intel Gaudi Profiler. Deprecate `HABANA_PROFILE` environment variable from HPUProfiler. ([#158](https://github.com/Lightning-AI/lightning-Habana/pull/158))
 - Added support for FP8 inference. ([#162](https://github.com/Lightning-AI/lightning-Habana/pull/162))
 - Added support for LightningCLI. ([#173](https://github.com/Lightning-AI/lightning-Habana/pull/173))
+- Added support for FP8 inference with DeepSpeed([#176](https://github.com/Lightning-AI/lightning-Habana/pull/173))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Intel Gaudi Profiler. Deprecate `HABANA_PROFILE` environment variable from HPUProfiler. ([#158](https://github.com/Lightning-AI/lightning-Habana/pull/158))
 - Added support for FP8 inference. ([#162](https://github.com/Lightning-AI/lightning-Habana/pull/162))
 - Added support for LightningCLI. ([#173](https://github.com/Lightning-AI/lightning-Habana/pull/173))
-- Added support for FP8 inference with DeepSpeed. ([#176](https://github.com/Lightning-AI/lightning-Habana/pull/173))
+- Added support for FP8 inference with DeepSpeed([#176](https://github.com/Lightning-AI/lightning-Habana/pull/176))
 
 ### Changed
 

--- a/docs/source/intermediate.rst
+++ b/docs/source/intermediate.rst
@@ -161,7 +161,7 @@ The plugin accepts following args for the fp8 training:
 
 .. note::
 
-    To enable fp8 training with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.deepspeed_precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
+    To enable fp8 training with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, instead of HPUPrecisionPlugin, while keeping all other steps the same.
 
 For more details on `transformer_engine` and `recipes`, refer to `FP8 Training with Intel Gaudi Transformer Engine <https://docs.habana.ai/en/latest/PyTorch/PyTorch_FP8_Training/index.html>`__.
 
@@ -248,7 +248,7 @@ Refer to `Supported JSON Config File Options <https://docs.habana.ai/en/latest/P
 
 .. note::
 
-    To enable fp8 inference with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.deepspeed_precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
+    To enable fp8 inference with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, instead of HPUPrecisionPlugin, while keeping all other steps the same.
 
 
 **Limitations**

--- a/docs/source/intermediate.rst
+++ b/docs/source/intermediate.rst
@@ -115,6 +115,7 @@ fp8 Training
 -------------
 
 Lightning supports fp8 training using HPUPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.precision.HPUPrecisionPlugin`.
+
 fp8 training is only available on Gaudi2 and above. Output from fp8 supported modules is in `torch.bfloat16`.
 
 The plugin accepts following args for the fp8 training:
@@ -157,8 +158,12 @@ The plugin accepts following args for the fp8 training:
 
     Users may still use `HPUPrecisionPlugin` to train in `bf16-mixed` precision for modules not supported by `transformer_engine`.
 
-For more details on `transformer_engine` and `recipes`, refer to `FP8 Training with Intel Gaudi Transformer Engine <https://docs.habana.ai/en/latest/PyTorch/PyTorch_FP8_Training/index.html>`__.
 
+.. note::
+
+    To enable fp8 training with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
+
+For more details on `transformer_engine` and `recipes`, refer to `FP8 Training with Intel Gaudi Transformer Engine <https://docs.habana.ai/en/latest/PyTorch/PyTorch_FP8_Training/index.html>`__.
 
 
 ----
@@ -239,6 +244,12 @@ HQT uses configuration jsons for selecting between quant and measurement modes. 
 User may also set `QUANT_CONFIG` environment variable pointing to the json to use during training.
 
 Refer to `Supported JSON Config File Options <https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_FP8.html#supported-json-config-file-options>`__ for more information.
+
+
+.. note::
+
+    To enable fp8 inference with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
+
 
 **Limitations**
 

--- a/docs/source/intermediate.rst
+++ b/docs/source/intermediate.rst
@@ -161,7 +161,7 @@ The plugin accepts following args for the fp8 training:
 
 .. note::
 
-    To enable fp8 training with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
+    To enable fp8 training with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.deepspeed_precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
 
 For more details on `transformer_engine` and `recipes`, refer to `FP8 Training with Intel Gaudi Transformer Engine <https://docs.habana.ai/en/latest/PyTorch/PyTorch_FP8_Training/index.html>`__.
 
@@ -248,7 +248,7 @@ Refer to `Supported JSON Config File Options <https://docs.habana.ai/en/latest/P
 
 .. note::
 
-    To enable fp8 inference with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
+    To enable fp8 inference with HPUDeepSpeedStrategy, use HPUDeepSpeedPrecisionPlugin, :class:`~lightning_habana.pytorch.plugins.deepspeed_precision.HPUDeepSpeedPrecisionPlugin` instead of HPUPrecisionPlugin, while keeping all other steps the same.
 
 
 **Limitations**

--- a/src/lightning_habana/pytorch/plugins/deepspeed_precision.py
+++ b/src/lightning_habana/pytorch/plugins/deepspeed_precision.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Union
+from typing import Any, Callable, Mapping, Optional, Union
 
 import torch
 from lightning_utilities import module_available
@@ -50,7 +50,7 @@ _HPU_DEEPSPEED_AVAILABLE = (
     # HPU deep speed is supported only through this pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.15.1
     RequirementCache("deepspeed==0.12.4+hpu.synapse.v1.15.1")
 )
-if TYPE_CHECKING and _HPU_DEEPSPEED_AVAILABLE:
+if _HPU_DEEPSPEED_AVAILABLE:
     import deepspeed
 
 
@@ -155,7 +155,6 @@ class HPUDeepSpeedPrecisionPlugin(HPUPrecisionPlugin):
 
         htcore.hpu_set_env()
         module = module.to("hpu")
-        import deepspeed
 
         module = deepspeed.init_inference(module, **ds_inference_kwargs)
         super()._setup_fp8_inference_modules(module, quant, fp8_data_path)

--- a/src/lightning_habana/pytorch/plugins/precision.py
+++ b/src/lightning_habana/pytorch/plugins/precision.py
@@ -106,6 +106,61 @@ class HPUPrecisionPlugin(Precision):
                 f"fp8 inference available: {self.fp8_inference_available}."
             )
 
+    def _setup_fp8_quant_config(self, quant: bool = True, fp8_data_path: Optional[str] = None) -> None:
+        """Setup QUANT_CONFIG for before importing HQT."""
+        if os.environ.get("QUANT_CONFIG", None) is None:
+            # Use default jsons in case one is not provided via env variable
+            fp8_data_path = fp8_data_path if fp8_data_path is not None else os.environ.get("HABANA_LOGS")
+            assert fp8_data_path is not None
+            # Create a copy in fp8_dump_path to avoid modifying package jsons.
+            fp8_json = MAXABS_QUANT if quant else MAXABS_MEASURE
+            if fp8_data_path is not None:
+                modify_fp8_json(
+                    file_path=fp8_json,
+                    patch={
+                        "dump_stats_path": os.path.join(fp8_data_path, "hqt"),
+                        "dump_stats_xlsx_path": os.path.join(fp8_data_path, "hqt", "fp8stats.xlsx"),
+                    },
+                )
+            os.environ["QUANT_CONFIG"] = fp8_json
+
+    def _enable_fp8_inference(
+        self, module: torch.nn.Module, quant: bool = True, fp8_data_path: Optional[str] = None
+    ) -> None:
+        """Convert module for fp8 inference.
+
+        This module cannot be used to run trainer.fit.
+
+        """
+        self._setup_fp8_quant_config(quant, fp8_data_path)
+        from quantization_toolkit import habana_quantization_toolkit
+
+        htcore.hpu_set_env()
+        try:
+            module = module.to("hpu")
+            habana_quantization_toolkit.prep_model(module)
+            htcore.hpu_initialize(module)
+        except FileNotFoundError as e:
+            print(
+                "Please run the fp8 measurement using a portion of data and try again. "
+                "Use HPUPrecisionPlugin.convert_modules(module, inference=True, quant=False) "
+                "and run trainer.fit() to dump measurement data."
+            )
+            raise e
+
+    def _enable_fp8_training(self, module: torch.nn.Module) -> None:
+        """Convert module for fp8 training."""
+        # In case model already contains a transformer engine modules,
+        # assume user responsibility for conversion of required layers.
+        if any(
+            "habana_frameworks.torch.hpex.experimental.transformer_engine" in m.__module__ for m in module.modules()
+        ):
+            rank_zero_info(
+                f"Module {module} already contains transformer engine equivalent modules. Skipping conversion"
+            )
+        else:
+            _replace_layers(module)
+
     def convert_modules(
         self,
         module: torch.nn.Module,
@@ -115,51 +170,9 @@ class HPUPrecisionPlugin(Precision):
     ) -> torch.nn.Module:
         """Enable support for fp8."""
         if inference is True and self.fp8_inference_available:
-            # Convert module for fp8 inference. This module cannot be used to run trainer.fit.
-            # Env needs to be set before importing Habana Quantization Toolkit
-            if os.environ.get("QUANT_CONFIG", None) is None:
-                # Use default jsons in case one is not provided via env variable
-                fp8_data_path = fp8_data_path if fp8_data_path is not None else os.environ.get("HABANA_LOGS")
-                assert fp8_data_path is not None
-                # Create a copy in fp8_dump_path to avoid modifying package jsons.
-                fp8_json = MAXABS_QUANT if quant else MAXABS_MEASURE
-                if fp8_data_path is not None:
-                    modify_fp8_json(
-                        file_path=fp8_json,
-                        patch={
-                            "dump_stats_path": os.path.join(fp8_data_path, "hqt"),
-                            "dump_stats_xlsx_path": os.path.join(fp8_data_path, "hqt", "fp8stats.xlsx"),
-                        },
-                    )
-                os.environ["QUANT_CONFIG"] = fp8_json
-
-            from quantization_toolkit import habana_quantization_toolkit  # noqa
-
-            htcore.hpu_set_env(module)
-            try:
-                module = module.to("hpu")
-                habana_quantization_toolkit.prep_model(module)
-                htcore.hpu_initialize(module)
-            except FileNotFoundError as e:
-                print(
-                    "Please run the fp8 measurement using a portion of data and try again. "
-                    "Use HPUPrecisionPlugin.convert_modules(module, inference=True, quant=False) "
-                    "and run trainer.fit() to dump measurement data."
-                )
-                raise e
-
+            self._enable_fp8_inference(module, quant, fp8_data_path)
         if self.fp8_train_available is True and self.replace_layers is True and inference is False:
-            # Convert module for fp8 training.
-            # In case model already contains a transformer engine modules,
-            # assume user responsibility for conversion of required layers.
-            if any(
-                "habana_frameworks.torch.hpex.experimental.transformer_engine" in m.__module__ for m in module.modules()
-            ):
-                rank_zero_info(
-                    f"Module {module} already contains transformer engine equivalent modules. Skipping conversion"
-                )
-            else:
-                _replace_layers(module)
+            self._enable_fp8_training(module)
         return module
 
     def autocast_context_manager(self) -> Union[ContextManager[Any], torch.autocast]:

--- a/src/lightning_habana/pytorch/strategies/deepspeed.py
+++ b/src/lightning_habana/pytorch/strategies/deepspeed.py
@@ -931,6 +931,20 @@ class HPUDeepSpeedStrategy(HPUDDPStrategy):
         # Override to do nothing, the deepspeed engine already loaded the states in `load_checkpoint()`
         pass
 
+    def on_test_end(self) -> None:
+        if self.precision_plugin.precision == "fp8" and self.precision_plugin.fp8_inference_available:
+            from quantization_toolkit import habana_quantization_toolkit  # noqa
+
+            habana_quantization_toolkit.finish_measurements(self.model)
+        return super().on_test_end()
+
+    def on_predict_end(self) -> None:
+        if self.precision_plugin.precision == "fp8" and self.precision_plugin.fp8_inference_available:
+            from quantization_toolkit import habana_quantization_toolkit  # noqa
+
+            habana_quantization_toolkit.finish_measurements(self.model)
+        return super().on_predict_end()
+
     @classmethod
     def register_strategies(cls, strategy_registry: _StrategyRegistry) -> None:
         strategy_registry.register("hpu_deepspeed", cls, description="Default DeepSpeed Strategy")

--- a/tests/test_pytorch/test_deepspeed.py
+++ b/tests/test_pytorch/test_deepspeed.py
@@ -16,8 +16,11 @@ import json
 import os
 from typing import Any, Dict
 
+import habana_frameworks.torch.hpex.experimental.transformer_engine as tengine
 import pytest
 import torch
+from habana_frameworks.torch.hpex.experimental.transformer_engine import recipe
+from lightning import seed_everything
 from lightning_utilities import module_available
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
@@ -191,8 +194,10 @@ def test_hpu_deepspeed_strategy_env(tmpdir, monkeypatch, deepspeed_config):
     assert strategy.config == deepspeed_config
 
 
-def test_hpu_deepspeed_precision_choice(tmpdir):
-    _plugins = [HPUDeepSpeedPrecisionPlugin(precision="bf16-mixed")]
+@pytest.mark.parametrize("precision", ["bf16-mixed", "fp8"])
+def test_hpu_deepspeed_precision_choice(tmpdir, precision):
+    """Tests precision plugin with supported precisions."""
+    _plugins = [HPUDeepSpeedPrecisionPlugin(precision=precision)]
     trainer = Trainer(
         fast_dev_run=True,
         default_root_dir=tmpdir,
@@ -203,7 +208,7 @@ def test_hpu_deepspeed_precision_choice(tmpdir):
 
     assert isinstance(trainer.strategy, HPUDeepSpeedStrategy)
     assert isinstance(trainer.strategy.precision_plugin, HPUDeepSpeedPrecisionPlugin)
-    assert trainer.strategy.precision_plugin.precision == "bf16-mixed"
+    assert trainer.strategy.precision_plugin.precision == precision
 
 
 def test_hpu_deepspeed_with_invalid_config_path():
@@ -772,3 +777,155 @@ def test_lightning_deepspeed_inference_config(get_device_count, dtype):
     assert torch.allclose(
         preds[0].detach().to(torch.float), expected
     ), f"incorrect result value {preds}, expected {expected}"
+
+
+@pytest.mark.parametrize("stage", [1, 2, 3])
+@pytest.mark.skipif(HPUAccelerator.get_device_name() == "GAUDI", reason="fp8 supported on Gaudi2 and above.")
+def test_hpu_deepspeed_fp8_training_accuracy(tmpdir, get_device_count, stage):
+    """Test compare training accuracy between bf16 and fp8 precision for deepspeed."""
+
+    class TestModel(BoringModel):
+        """Test model."""
+
+        def __init__(self):
+            """init."""
+            super().__init__()
+            self.layer = tengine.Linear(32, 2)
+
+        def training_step(self, batch, batch_idx):
+            """Training step."""
+            loss = super().training_step(batch, batch_idx)
+            self.log("train_loss", loss.get("loss"), prog_bar=True, sync_dist=True)
+            return loss
+
+        def validation_step(self, batch, batch_idx):
+            """Validation step."""
+            loss = super().validation_step(batch, batch_idx)
+            self.log("val_loss", loss.get("x"), prog_bar=True, sync_dist=True)
+            return loss
+
+        def configure_optimizers(self):
+            """Configure optimizer."""
+            from torch.optim.adamw import AdamW
+
+            return AdamW(self.parameters())
+
+    def run_training(tmpdir, model, plugin, strategy):
+        """Runs a model and returns loss."""
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            fast_dev_run=True,
+            accelerator=HPUAccelerator(),
+            devices=get_device_count,
+            strategy=strategy,
+            plugins=plugin,
+        )
+        trainer.fit(model)
+        return trainer.callback_metrics["val_loss"], trainer.callback_metrics["train_loss"]
+
+    precision_plugin_params_list = [
+        ({"device": "hpu", "precision": "bf16-mixed"}),
+        ({"device": "hpu", "precision": "fp8", "replace_layers": True, "recipe": recipe.DelayedScaling()}),
+    ]
+
+    loss_list = []
+
+    for params in precision_plugin_params_list:
+        seed_everything(42)
+        model = TestModel()
+        _plugin = HPUDeepSpeedPrecisionPlugin(**params)
+        _strategy = HPUDeepSpeedStrategy(stage=stage)
+        loss_list.append(run_training(tmpdir, model, _plugin, _strategy))
+
+    assert torch.allclose(torch.tensor(loss_list[0][1]), torch.tensor(loss_list[1][1]), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.standalone_only()
+@pytest.mark.skipif(HPUAccelerator.get_device_name() == "GAUDI", reason="Accessory test for fp8 inference.")
+def test_hpu_deepspeed_bf16_inference_accuracy(tmpdir, get_device_count):
+    """Test maintain bf16 test loss used in fp8 inference accuracy test using deepspeed."""
+
+    class TestModel(BoringModel):
+        """Test model."""
+
+        def __init__(self):
+            """init."""
+            super().__init__()
+            self.layer = torch.nn.Linear(32, 2)
+
+        def test_step(self, batch, batch_idx):
+            """Training step."""
+            loss = super().test_step(batch, batch_idx)
+            self.log("test_loss", loss.get("y"), prog_bar=True, sync_dist=True)
+            return loss
+
+    def run_training(tmpdir, model, plugin, strategy):
+        """Runs a model and returns loss."""
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            accelerator=HPUAccelerator(),
+            devices=get_device_count,
+            strategy=strategy,
+            plugins=plugin,
+            fast_dev_run=True,
+        )
+        trainer.test(model)
+        return trainer.callback_metrics["test_loss"]
+
+    seed_everything(42)
+    model = TestModel()
+    _plugin = HPUDeepSpeedPrecisionPlugin(precision="bf16-mixed")
+    _strategy = HPUDeepSpeedStrategy()
+
+    bf16_test_loss = run_training(tmpdir, model, _plugin, _strategy)
+    bf16_loss = torch.tensor(0.414062)
+    if get_device_count == 2:
+        bf16_loss = torch.tensor(1.253906)
+    assert torch.allclose(bf16_test_loss, bf16_loss, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.standalone_only()  # HQT cannot be reconfigured in same process
+@pytest.mark.parametrize("quant", [False, True])
+@pytest.mark.skipif(HPUAccelerator.get_device_name() == "GAUDI", reason="fp8 supported on Gaudi2 and above.")
+def test_hpu_deepspeed_fp8_inference_accuracy(tmpdir, get_device_count, quant):
+    """Test compare inference accuracy between bf16 and fp8 precision for deepspeed."""
+
+    class TestModel(BoringModel):
+        """Test model."""
+
+        def __init__(self):
+            """init."""
+            super().__init__()
+            self.layer = torch.nn.Linear(32, 2)
+
+        def test_step(self, batch, batch_idx):
+            """Training step."""
+            loss = super().test_step(batch, batch_idx)
+            self.log("test_loss", loss.get("y"), prog_bar=True, sync_dist=True)
+            return loss
+
+    def run_training(tmpdir, model, plugin, strategy):
+        """Runs a model and returns loss."""
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            accelerator=HPUAccelerator(),
+            devices=get_device_count,
+            strategy=strategy,
+            plugins=plugin,
+            fast_dev_run=True,
+        )
+        trainer.test(model)
+        return trainer.callback_metrics["test_loss"]
+
+    seed_everything(42)
+    model = TestModel()
+    _plugin = HPUDeepSpeedPrecisionPlugin(precision="fp8")
+    _strategy = HPUDeepSpeedStrategy()
+    _plugin.convert_modules(model, inference=True, quant=quant)
+
+    fp8_test_loss = run_training(tmpdir, model, _plugin, _strategy)
+    if quant is True:
+        bf16_loss = torch.tensor(0.4141)
+        if get_device_count == 2:
+            bf16_loss = torch.tensor(1.253906)
+        assert torch.allclose(fp8_test_loss, bf16_loss, rtol=1e-2, atol=1e-2)

--- a/tests/test_pytorch/test_precision.py
+++ b/tests/test_pytorch/test_precision.py
@@ -327,7 +327,7 @@ def test_hpu_precision_fp8_inference_quantization(tmpdir):
 
 @pytest.mark.standalone_only()
 @pytest.mark.skipif(HPUAccelerator.get_device_name() == "GAUDI", reason="fp8 supported on Gaudi2 and above.")
-def test_hpu_precision_fp8_with_ddp_strategy(tmpdir):
+def test_hpu_precision_fp8_with_ddp_strategy(tmpdir, hpus):
     """Negative test for fp8 inference not supported with HPUDDPStrategy."""
     model = BoringModel()
     dm = BoringDataModule()
@@ -337,7 +337,7 @@ def test_hpu_precision_fp8_with_ddp_strategy(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         accelerator=HPUAccelerator(),
-        devices=2,
+        devices=hpus,
         strategy=HPUDDPStrategy(),
         plugins=plugin,
     )


### PR DESCRIPTION
<details>
  <summary><b>Add fp8 training and inference support to deepspeed </b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?
Add fp8 training and inference support to deepspeed

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
