### PR TITLE
Workaround to resolve label name issue with torch.compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed deepspeed documentation & tests based on synapse AI release 1.15.1 and latest PTL fabric. ([#184](https://github.com/Lightning-AI/lightning-Habana/pull/184))
+- Workaround to resolve label name issue in HPUProfiler with torch.compile. ([#185](https://github.com/Lightning-AI/lightning-Habana/pull/185))
 
 ### Removed
 

--- a/src/lightning_habana/pytorch/profiler/profiler.py
+++ b/src/lightning_habana/pytorch/profiler/profiler.py
@@ -86,7 +86,7 @@ class HPUProfiler(PyTorchProfiler):
         export_to_chrome: bool = True,
         row_limit: int = 20,
         sort_by_key: Optional[str] = None,
-        record_module_names: bool = True,
+        record_module_names: bool = False,
         **profiler_kwargs: Any,
     ) -> None:
         assert os.environ.get("HABANA_PROFILE", None) in (


### PR DESCRIPTION
<details>
  <summary><b>Add test for HPUProfiler with torch.compile</b></summary>

- [ ] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?
Showcases dependency of HPUProfiler with lightning core leading to  incompatibility with torch.compile.
Raises TypeError: nullcontext.__enter__() missing 1 required positional argument: 'self'
![image](https://github.com/Lightning-AI/lightning-Habana/assets/19816289/c9dce68f-aa22-4f26-8bcb-b53c4154cf5c)

Issue: https://github.com/Lightning-AI/pytorch-lightning/issues/19253

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃