### PR TITLE
redirect PL imports to `torch`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,13 +122,13 @@ exclude = [
 "examples/**" = ["D100", "D101", "D102", "D104", "D107"]  # TODO: fix all of these
 "tests/**" = ["D100", "D101", "D102", "D103", "D104", "D107"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"
 
 #[tool.ruff.pycodestyle]
 #ignore-overlong-task-comments = true
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10

--- a/src/lightning_habana/pytorch/strategies/deepspeed.py
+++ b/src/lightning_habana/pytorch/strategies/deepspeed.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Mapping, Optional,
 
 from lightning_utilities import module_available
 from lightning_utilities.core.imports import RequirementCache
+from pytorch_lightning.utilities.types import LRSchedulerConfig
+from torch.optim.lr_scheduler import LRScheduler, ReduceLROnPlateau
 
 if module_available("lightning"):
     from lightning.fabric.plugins import ClusterEnvironment
@@ -34,7 +36,7 @@ if module_available("lightning"):
     )
     from lightning.fabric.utilities.optimizer import _optimizers_to_device
     from lightning.fabric.utilities.seed import reset_seed
-    from lightning.fabric.utilities.types import _PATH, LRScheduler, ReduceLROnPlateau
+    from lightning.fabric.utilities.types import _PATH
     from lightning.pytorch import LightningModule, Trainer
     from lightning.pytorch.accelerators import Accelerator
     from lightning.pytorch.core.optimizer import _init_optimizers_and_lr_schedulers
@@ -44,7 +46,6 @@ if module_available("lightning"):
     from lightning.pytorch.utilities.exceptions import MisconfigurationException
     from lightning.pytorch.utilities.model_helpers import is_overridden
     from lightning.pytorch.utilities.rank_zero import WarningCache, rank_zero_info, rank_zero_warn
-    from lightning.pytorch.utilities.types import LRSchedulerConfig
 elif module_available("pytorch_lightning"):
     from lightning_fabric.plugins import ClusterEnvironment
     from lightning_fabric.strategies import _StrategyRegistry
@@ -54,7 +55,7 @@ elif module_available("pytorch_lightning"):
     )
     from lightning_fabric.utilities.optimizer import _optimizers_to_device
     from lightning_fabric.utilities.seed import reset_seed
-    from lightning_fabric.utilities.types import _PATH, LRScheduler, ReduceLROnPlateau
+    from lightning_fabric.utilities.types import _PATH
     from pytorch_lightning import LightningModule, Trainer
     from pytorch_lightning.accelerators import Accelerator
     from pytorch_lightning.core.optimizer import _init_optimizers_and_lr_schedulers
@@ -64,7 +65,6 @@ elif module_available("pytorch_lightning"):
     from pytorch_lightning.utilities.exceptions import MisconfigurationException
     from pytorch_lightning.utilities.model_helpers import is_overridden
     from pytorch_lightning.utilities.rank_zero import WarningCache, rank_zero_info, rank_zero_warn
-    from pytorch_lightning.utilities.types import LRSchedulerConfig
 
 import torch
 from torch.nn import Module

--- a/src/lightning_habana/pytorch/strategies/deepspeed.py
+++ b/src/lightning_habana/pytorch/strategies/deepspeed.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, List, Mapping, Optional,
 
 from lightning_utilities import module_available
 from lightning_utilities.core.imports import RequirementCache
-from pytorch_lightning.utilities.types import LRSchedulerConfig
 from torch.optim.lr_scheduler import LRScheduler, ReduceLROnPlateau
 
 if module_available("lightning"):
@@ -46,6 +45,7 @@ if module_available("lightning"):
     from lightning.pytorch.utilities.exceptions import MisconfigurationException
     from lightning.pytorch.utilities.model_helpers import is_overridden
     from lightning.pytorch.utilities.rank_zero import WarningCache, rank_zero_info, rank_zero_warn
+    from lightning.pytorch.utilities.types import LRSchedulerConfig
 elif module_available("pytorch_lightning"):
     from lightning_fabric.plugins import ClusterEnvironment
     from lightning_fabric.strategies import _StrategyRegistry
@@ -65,6 +65,7 @@ elif module_available("pytorch_lightning"):
     from pytorch_lightning.utilities.exceptions import MisconfigurationException
     from pytorch_lightning.utilities.model_helpers import is_overridden
     from pytorch_lightning.utilities.rank_zero import WarningCache, rank_zero_info, rank_zero_warn
+    from pytorch_lightning.utilities.types import LRSchedulerConfig
 
 import torch
 from torch.nn import Module


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/agreed via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

reduce unnecessary dependency on PL
https://github.com/Lightning-AI/pytorch-lightning/blob/e6c26d2d22fc4678b2cf47d57697ebae68b09529/src/lightning/fabric/utilities/types.py#L32-L33

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
