### PR TITLE
Move the model back to HPU after each save

### DIFF
--- a/src/lightning_habana/pytorch/plugins/io_plugin.py
+++ b/src/lightning_habana/pytorch/plugins/io_plugin.py
@@ -60,3 +60,4 @@ class HPUCheckpointIO(TorchCheckpointIO):
         checkpoint = move_data_to_device(checkpoint, torch.device("cpu"))
         # write the checkpoint dictionary to the provided path
         _atomic_save(checkpoint, path)
+        move_data_to_device(checkpoint, torch.device("hpu"))


### PR DESCRIPTION
This PR addresses an issue in the HPUCheckpointIO class within the Habana Gaudi framework, where model parameters are  transferred from the HPU to the CPU during the checkpointing process. This behavior causes subsequent training steps to fail, as the model is no longer on the expected device (HPU), resulting in errors and halted training.

When a checkpoint is saved using HPUCheckpointIO, the current implementation moves the entire checkpoint dictionary, including model parameters, to the CPU before saving. However, the model parameters are not moved back to the HPU after the checkpoint is saved, causing the model to remain on the CPU. This leads to unexpected behavior during training, specifically:

1. The model's device is unexpectedly changed from HPU to CPU.
2. Subsequent training or validation steps fail, as the model is not on the expected device.

The proposed fix involves adding a step to move the model parameters back to the HPU immediately after the checkpoint is saved. This ensures that the model remains on the HPU throughout the training process. T